### PR TITLE
Added search

### DIFF
--- a/src/routes/Dashboard/DashboardToolBar.tsx
+++ b/src/routes/Dashboard/DashboardToolBar.tsx
@@ -1,13 +1,20 @@
-import React, { Fragment, memo } from 'react'
+import React, { Fragment, memo, useState } from 'react'
 import ToolBar, { ToolBarLink } from '../../components/ToolBar'
 import { Input } from './styled'
 
 interface DashboardToolBarProps {
   department: string
   category: string
+  search: string
+  setSearch: (input: string) => void
 }
 
-const DashboardToolBar = ({ department, category }: DashboardToolBarProps) => (
+const DashboardToolBar = ({
+  department,
+  category,
+  search,
+  setSearch
+}: DashboardToolBarProps) => (
   <ToolBar
     title='Dashboard'
     links={
@@ -16,7 +23,14 @@ const DashboardToolBar = ({ department, category }: DashboardToolBarProps) => (
         <ToolBarLink to={`/${department}/projects`}>Projects</ToolBarLink>
       </Fragment>
     }
-    children={<Input placeholder={`Search ${category}`} />}
+    children={
+      <Input
+        autoFocus
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        placeholder={`Search ${category}`}
+      />
+    }
   />
 )
 

--- a/src/routes/Dashboard/DashboardToolBar.tsx
+++ b/src/routes/Dashboard/DashboardToolBar.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, memo, useState } from 'react'
+import React, { Fragment, memo } from 'react'
 import ToolBar, { ToolBarLink } from '../../components/ToolBar'
 import { Input } from './styled'
 

--- a/src/routes/Dashboard/index.tsx
+++ b/src/routes/Dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, Suspense, memo } from 'react'
+import React, { Fragment, Suspense, memo, useState } from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router-dom'
 import gql from 'graphql-tag'
 import ErrorBoundary from 'react-error-boundary'
@@ -66,9 +66,16 @@ const distances = {
 const Dashboard = ({ match }: Props) => {
   const { department, category } = match!.params
 
+  const [search, setSearch] = useState('')
+
   return (
     <Fragment>
-      <DashboardToolBar department={department} category={category} />
+      <DashboardToolBar
+        department={department}
+        category={category}
+        search={search}
+        setSearch={setSearch}
+      />
 
       <StyledDashboard>
         <AuthenticatedQuery
@@ -98,29 +105,40 @@ const Dashboard = ({ match }: Props) => {
                   archived={archived.total}
                   width='32%'
                 />
+
                 <ActualityWidget
                   title='Libraries Actuality'
                   width='32%'
                   outdated={major.length}
                   total={libraries.length}
                 />
+
                 <RecentUpdates libraries={recentlyUpdated} width='32%' />
               </WidgetContainer>
             )
 
-            const renderLibraries = () => (
-              <NodeLibrariesTable
-                libraries={uniqueLibraries}
-                outdates={outdates}
-              />
-            )
+            const renderLibraries = () => {
+              const filtered = uniqueLibraries.filter(
+                ({ package: { name } }: any) => name.indexOf(search) > -1
+              )
 
-            const renderProjects = () => (
-              <NodeProjectsTable
-                department={department}
-                projects={projects.edges.map(({ node }: any) => node)}
-              />
-            )
+              return (
+                <NodeLibrariesTable libraries={filtered} outdates={outdates} />
+              )
+            }
+
+            const renderProjects = () => {
+              const filtered = projects.edges
+                .map(({ node }: any) => node)
+                .filter(({ name }: any) => name.indexOf(search) > -1)
+
+              return (
+                <NodeProjectsTable
+                  department={department}
+                  projects={filtered}
+                />
+              )
+            }
 
             return (
               <Suspense fallback={<Loading />}>

--- a/src/routes/Dashboard/index.tsx
+++ b/src/routes/Dashboard/index.tsx
@@ -119,7 +119,7 @@ const Dashboard = ({ match }: Props) => {
 
             const renderLibraries = () => {
               const filtered = uniqueLibraries.filter(
-                ({ package: { name } }: any) => name.indexOf(search) > -1
+                ({ package: { name } }: any) => name.includes(search)
               )
 
               return (
@@ -130,7 +130,7 @@ const Dashboard = ({ match }: Props) => {
             const renderProjects = () => {
               const filtered = projects.edges
                 .map(({ node }: any) => node)
-                .filter(({ name }: any) => name.indexOf(search) > -1)
+                .filter(({ name }: any) => name.includes(search))
 
               return (
                 <NodeProjectsTable

--- a/src/routes/Department/index.tsx
+++ b/src/routes/Department/index.tsx
@@ -31,7 +31,6 @@ const DepartmentPage = React.memo((props: DepartmentPageProps) => {
         path={routes.nodeProjectDetails}
         render={renderNodeProjectDetails}
       />
-      />
       <Route
         path={routes.nodeLibraryDetails}
         render={renderNodeLibraryDetails}

--- a/src/routes/NodeLibraryDetails/index.tsx
+++ b/src/routes/NodeLibraryDetails/index.tsx
@@ -61,8 +61,8 @@ const NodeLibraryDetails = ({ match, department }: Props) => {
           propEq('outdatedStatus', 'MAJOR')
         )
 
-        const filtered = library.dependents.edges.filter(
-          ({ node }: any) => node.repository.name.indexOf(search) > -1
+        const filtered = library.dependents.edges.filter(({ node }: any) =>
+          node.repository.name.includes(search)
         )
 
         return (

--- a/src/routes/NodeLibraryDetails/index.tsx
+++ b/src/routes/NodeLibraryDetails/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, Fragment } from 'react'
+import React, { Fragment, memo, useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import gql from 'graphql-tag'
 import { __, propEq } from 'ramda'
@@ -44,6 +44,7 @@ export interface Props extends RouteComponentProps<{ id: string }> {
 
 const NodeLibraryDetails = ({ match, department }: Props) => {
   const { id: name } = match!.params
+  const [search, setSearch] = useState('')
 
   return (
     <AuthenticatedQuery
@@ -60,6 +61,10 @@ const NodeLibraryDetails = ({ match, department }: Props) => {
           propEq('outdatedStatus', 'MAJOR')
         )
 
+        const filtered = library.dependents.edges.filter(
+          ({ node }: any) => node.repository.name.indexOf(search) > -1
+        )
+
         return (
           <Fragment>
             <ToolBar title={library.name} subtitle={library.version} />
@@ -67,11 +72,17 @@ const NodeLibraryDetails = ({ match, department }: Props) => {
               <Content>
                 <h2>Library projects</h2>
                 <div>
-                  <Input placeholder='Search for projects' />
+                  <Input
+                    autoFocus
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    placeholder='Search for projects'
+                  />
                 </div>
+
                 <NodeLibraryDependentsTable
                   libraryVersion={library.version}
-                  dependents={library.dependents.edges}
+                  dependents={filtered}
                   department={department}
                 />
               </Content>

--- a/src/routes/NodeProjectDetails/index.tsx
+++ b/src/routes/NodeProjectDetails/index.tsx
@@ -67,8 +67,8 @@ const NodeProjectDetails = ({ match, department }: Props) => {
           prop('package')
         )
 
-        const filtered = dependencies.filter(
-          (dependency: any) => dependency.package.name.indexOf(search) > -1
+        const filtered = dependencies.filter((dependency: any) =>
+          dependency.package.name.includes(search)
         )
 
         return (

--- a/src/routes/NodeProjectDetails/index.tsx
+++ b/src/routes/NodeProjectDetails/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, memo } from 'react'
+import React, { Fragment, memo, useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import { prop, propEq } from 'ramda'
 import gql from 'graphql-tag'
@@ -47,6 +47,7 @@ export interface Props extends RouteComponentProps<{ id: string }> {
 
 const NodeProjectDetails = ({ match, department }: Props) => {
   const { id: name } = match!.params
+  const [search, setSearch] = useState('')
 
   return (
     <AuthenticatedQuery query={PROJECT_QUERY} variables={{ name }}>
@@ -66,6 +67,10 @@ const NodeProjectDetails = ({ match, department }: Props) => {
           prop('package')
         )
 
+        const filtered = dependencies.filter(
+          (dependency: any) => dependency.package.name.indexOf(search) > -1
+        )
+
         return (
           <Fragment>
             <ToolBar
@@ -80,15 +85,21 @@ const NodeProjectDetails = ({ match, department }: Props) => {
               <Content>
                 <Body>Project libraries</Body>
                 <div>
-                  <Input placeholder='Search for libraries' />
+                  <Input
+                    autoFocus
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    placeholder='Search for libraries'
+                  />
                 </div>
                 <NodeProjectDependenciesTable
-                  dependencies={dependencies}
+                  dependencies={filtered}
                   department={department}
                 />
               </Content>
               <Sidebar>
                 <RecentUpdates libraries={recentLibraries} />
+
                 <ActualityWidget
                   title='Libraries Actuality'
                   mt={20}


### PR DESCRIPTION
Resolves #8 

Search was implemented as a client side state. Although GitHub provide proper searching capabilities, we rely on glob data to reach the dependencies of a project (reading package.json), so there is virtually no way to search libraries using the API.