### PR TITLE
Compile GraphQL in build time

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,8 @@
 
   "plugins": [
     "ramda",
-    "styled-components"
+    "styled-components",
+    "import-graphql"
   ],
 
   "env": { "test": { "plugins": ["rewire"] } }

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,2 @@
+// override config.
+module.exports = {}

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,2 +1,0 @@
-// override webpack config.
-module.exports = config => config

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@types/styled-system": "^3.0.6",
     "apollo": "^2.8.1",
     "awesome-typescript-loader": "^5.2.1",
+    "babel-plugin-import-graphql": "^2.7.0",
     "babel-plugin-ramda": "^1.6.3",
     "babel-plugin-rewire": "^1.2.0",
     "babel-plugin-styled-components": "^1.9.4",

--- a/src/containers/CurrentUserContainer/index.tsx
+++ b/src/containers/CurrentUserContainer/index.tsx
@@ -1,17 +1,8 @@
 import React from 'react'
-import gql from 'graphql-tag'
 
 import { CurrentUserContainerProps as Props, Result } from './types'
 import AuthenticatedQuery from '../AuthenticatedQuery'
-
-const CURRENT_USER_QUERY = gql`
-  query CURRENT_USER_QUERY {
-    user: viewer {
-      id
-      name
-    }
-  }
-`
+import { CURRENT_USER_QUERY } from './query.gql'
 
 const CurrentUserContainer = ({ children, ...rest }: Props) => (
   <AuthenticatedQuery query={CURRENT_USER_QUERY} {...rest}>

--- a/src/containers/CurrentUserContainer/query.gql
+++ b/src/containers/CurrentUserContainer/query.gql
@@ -1,0 +1,6 @@
+query CURRENT_USER_QUERY {
+  user: viewer {
+    id
+    name
+  }
+}

--- a/src/routes/Dashboard/index.tsx
+++ b/src/routes/Dashboard/index.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment, Suspense, memo, useState } from 'react'
 import { Route, RouteComponentProps, Switch } from 'react-router-dom'
-import gql from 'graphql-tag'
 import ErrorBoundary from 'react-error-boundary'
 
 import * as routes from '../routes'
@@ -15,43 +14,7 @@ import RecentUpdates from './RecentUpdates'
 import DashboardToolBar from './DashboardToolBar'
 import { TableContainer, StyledDashboard, WidgetContainer } from './styled'
 import { extractLibrariesInfo } from './helpers'
-
-const DASHBOARD_QUERY = gql`
-  query DASHBOARD_QUERY($department: BidaDepartment!) {
-    projects(first: 50, department: $department) {
-      total: repositoryCount
-      edges {
-        cursor
-        node {
-          ... on Repository {
-            id
-            name
-            pushedAt
-            npmPackage {
-              id
-              dependencies {
-                id
-                name
-                outdateStatus
-                package {
-                  id
-                  name
-                  version
-                  license
-                  updatedAt
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    archived: projects(department: $department, archived: true) {
-      total: repositoryCount
-    }
-  }
-`
+import { DASHBOARD_QUERY } from './query.gql'
 
 export interface Props
   extends RouteComponentProps<{

--- a/src/routes/Dashboard/query.gql
+++ b/src/routes/Dashboard/query.gql
@@ -1,0 +1,34 @@
+query DASHBOARD_QUERY($department: BidaDepartment!) {
+  projects(first: 50, department: $department) {
+    total: repositoryCount
+    edges {
+      cursor
+      node {
+        ... on Repository {
+          id
+          name
+          pushedAt
+          npmPackage {
+            id
+            dependencies {
+              id
+              name
+              outdateStatus
+              package {
+                id
+                name
+                version
+                license
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  archived: projects(department: $department, archived: true) {
+    total: repositoryCount
+  }
+}

--- a/src/routes/NodeLibraryDetails/index.tsx
+++ b/src/routes/NodeLibraryDetails/index.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment, memo, useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
-import gql from 'graphql-tag'
 import { __, propEq } from 'ramda'
 
 import ToolBar from '../../components/ToolBar'
@@ -12,31 +11,7 @@ import Loading from '../../components/Loading'
 
 import AuthenticatedQuery from '../../containers/AuthenticatedQuery'
 
-const NODE_LIBRARY_QUERY = gql`
-  query NODE_LIBRARY_QUERY($name: String!, $department: BidaDepartment!) {
-    library: npmPackage(name: $name) {
-      id
-      name
-      version
-
-      dependents(first: 100, department: $department) {
-        edges {
-          node {
-            ... on Dependent {
-              id
-              version
-              outdateStatus
-              repository {
-                id
-                name
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`
+import { NODE_LIBRARY_QUERY } from './query.gql'
 
 export interface Props extends RouteComponentProps<{ id: string }> {
   department: BidaDepartment

--- a/src/routes/NodeLibraryDetails/query.gql
+++ b/src/routes/NodeLibraryDetails/query.gql
@@ -1,0 +1,23 @@
+query NODE_LIBRARY_QUERY($name: String!, $department: BidaDepartment!) {
+  library: npmPackage(name: $name) {
+    id
+    name
+    version
+
+    dependents(first: 100, department: $department) {
+      edges {
+        node {
+          ... on Dependent {
+            id
+            version
+            outdateStatus
+            repository {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/routes/NodeProjectDetails/index.tsx
+++ b/src/routes/NodeProjectDetails/index.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment, memo, useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import { prop, propEq } from 'ramda'
-import gql from 'graphql-tag'
 
 import ToolBar from '../../components/ToolBar'
 import Anchor from '../../components/Anchor'
@@ -16,30 +15,7 @@ import { BidaDepartment } from '../../config/types'
 import AuthenticatedQuery from '../../containers/AuthenticatedQuery'
 import { getRecentlyUpdated } from '../Dashboard/helpers'
 
-const PROJECT_QUERY = gql`
-  query PROJECT_QUERY($name: String!) {
-    project(name: $name) {
-      id
-      url
-      name
-      npmPackage {
-        id
-        dependencies {
-          id
-          version
-          outdateStatus
-          package {
-            id
-            name
-            license
-            version
-            updatedAt
-          }
-        }
-      }
-    }
-  }
-`
+import { PROJECT_QUERY } from './query.gql'
 
 export interface Props extends RouteComponentProps<{ id: string }> {
   department: BidaDepartment

--- a/src/routes/NodeProjectDetails/query.gql
+++ b/src/routes/NodeProjectDetails/query.gql
@@ -1,0 +1,22 @@
+query PROJECT_QUERY($name: String!) {
+  project(name: $name) {
+    id
+    url
+    name
+    npmPackage {
+      id
+      dependencies {
+        id
+        version
+        outdateStatus
+        package {
+          id
+          name
+          license
+          version
+          updatedAt
+        }
+      }
+    }
+  }
+}

--- a/types/assets/index.d.ts
+++ b/types/assets/index.d.ts
@@ -1,1 +1,2 @@
 declare module '*.svg'
+declare module '*.gql'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,6 +3956,13 @@ babel-plugin-emotion@^10.0.7, babel-plugin-emotion@^10.0.9:
     find-root "^1.1.0"
     source-map "^0.5.7"
 
+babel-plugin-import-graphql@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-import-graphql/-/babel-plugin-import-graphql-2.7.0.tgz#984b2330afa05cce5ff81e577f7d82cdb86aea6d"
+  integrity sha512-PCNT6hLXaFxb7bsXJ+ALFnEnZUK2Hj1HhM0nWv4XDpuYf8arulm7ZAu/Z0MBItLkcik/TAokGX9IUzwyTYMXvQ==
+  dependencies:
+    graphql-tag "^2.9.2"
+
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"


### PR DESCRIPTION
This pull-request adds `.gql` file compilation using `graphql-tag` on build time. It reduces bundle size from **~660 KB** to **~640.0 KB**, and should probably improve application's initialization a bit due to less runtime processing.

Next GraphQL optimization should probably be #49 

---

## Original issue

Currently, every GraphQL code is being compiled in run-time. This is a _huge_ performance issue, both on runtime processing and bundle size (presence of compilation libraries).

The alternative is to use babel loaders for parsing GraphQL schemas and queries into AST on build time:

**1. babel-plugin-import-graphql**
Easy setup, with rewire capabilities for create-react-app.

**2. babel-plugin-graphql-tag**
Harder setup, but support for progressive enhancements, such as [persisted queries](https://blog.apollographql.com/persisted-graphql-queries-with-apollo-client-119fd7e6bba5).

I strongly recommend going with the second option, but benefits of that might only appear when we move the API to a dedicated backend.