### PR TITLE
Fix: update cacheKey path

### DIFF
--- a/src/components/NodeLibraryDependentsTable/index.tsx
+++ b/src/components/NodeLibraryDependentsTable/index.tsx
@@ -58,7 +58,7 @@ const normalize = mem(
     version: dependent.version,
     distance: versionDistance(libraryVersion, dependent.version),
   }),
-  { cacheKey: path(['node', 'id']) }
+  { cacheKey: path(['id']) }
 )
 
 const NodeLibraryDependentsTable: FunctionComponent<IProps> = ({


### PR DESCRIPTION
## Issue #75 
Fixed library project list by updating the cachePatha nd thus fixing the caching mechanism inside `NodeLibraryDependentsTable`

Before:

![Screenshot from 2020-05-04 13-01-41](https://user-images.githubusercontent.com/13395909/80961172-a6f34780-8e0a-11ea-9c1d-d4ed89dae2e3.png)

After:

![Screenshot from 2020-05-04 13-22-31](https://user-images.githubusercontent.com/13395909/80961188-b1154600-8e0a-11ea-9296-0aa5f649ff8d.png)
