### PR TITLE
Changed default sorting for libraries

### DIFF
--- a/src/components/NodeLibrariesTable/index.tsx
+++ b/src/components/NodeLibrariesTable/index.tsx
@@ -2,7 +2,7 @@ import React, { memo, useMemo, FunctionComponent } from 'react'
 import mem from 'mem'
 
 import {
-  ascend,
+  descend,
   filter,
   length as len,
   map,
@@ -50,7 +50,7 @@ export interface NodeLibrariesTableProps {
   outdates: Outdates
 }
 
-const defaultSort = ascend(prop('name'))
+const defaultSort = descend(prop('usage'))
 
 const sumObject = pipe<Record<Distances, number>, number[], number>(values, sum)
 
@@ -113,8 +113,8 @@ const NodeLibrariesTable: FunctionComponent<NodeLibrariesTableProps> = ({
     list,
     cacheKeys,
     defaultSort,
-    sortBy: 'name',
-    sortDirection: 'ASC',
+    sortBy: 'usage',
+    sortDirection: 'DESC',
   })
 
   // renderers.


### PR DESCRIPTION
## Issue #77 

Changed the default sorting for libraries list in `NodeLibrariesTable` from ASC `name` to DESC `usage`

#### Before:

![Screenshot from 2020-05-04 13-56-19](https://user-images.githubusercontent.com/13395909/80963426-31d64100-8e0f-11ea-8201-c8105150d0b6.png)

#### After:

![Screenshot from 2020-05-04 13-55-34](https://user-images.githubusercontent.com/13395909/80963435-36025e80-8e0f-11ea-84ba-80ff696a5b84.png)
