### PR TITLE
Changed default projects sorting to DESC pushedAt

### DIFF
--- a/src/components/NodeProjectsTable/index.tsx
+++ b/src/components/NodeProjectsTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from 'react'
 import mem from 'mem'
-import { ascend, propEq, prop, sum } from 'ramda'
+import { propEq, prop, sum } from 'ramda'
 
 import Table, { Column } from '../Table/index'
 import StatusColumn from '../Table/StatusColumn'
@@ -72,9 +72,8 @@ const normalizeProject = mem(
 
 const sortDefaults: UseSortOptions<NormalizedProject> = {
   list: [],
-  defaultSort: ascend(prop('name')),
-  sortBy: 'name',
-  sortDirection: 'ASC',
+  sortBy: 'pushedAt',
+  sortDirection: 'DESC',
 }
 
 const NodeProjectsTable = ({ projects, department, cacheKey }: NodeProjectsTableProps) => {


### PR DESCRIPTION
## Issue #80 

Changed default sorting on projects page to last active (`pushedAt` attribute)

#### Before (sorting defaults to name)

![Screenshot from 2020-05-04 17-35-45](https://user-images.githubusercontent.com/13395909/80984330-ff880c00-8e2d-11ea-8b63-1ee7ffd2864b.png)


#### After (sorting default to last active)

![Screenshot from 2020-05-04 17-35-17](https://user-images.githubusercontent.com/13395909/80984336-0282fc80-8e2e-11ea-9f52-af5f8eb0fc36.png)
